### PR TITLE
Add several features/optimizations for SPIRE

### DIFF
--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/pod"
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
+	"github.com/tektoncd/pipeline/pkg/spire"
 	"github.com/tektoncd/pipeline/pkg/taskrunmetrics"
 	"k8s.io/client-go/tools/cache"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -62,7 +63,7 @@ func NewController(opts *pipeline.Options, clock clock.Clock) func(context.Conte
 			KubeClientSet:     kubeclientset,
 			PipelineClientSet: pipelineclientset,
 			Images:            opts.Images,
-			SpireConfig:       opts.SpireConfig,
+			SpireClient:       spire.NewSpireServerApiClient(opts.SpireConfig),
 			Clock:             clock,
 			taskRunLister:     taskRunInformer.Lister(),
 			resourceLister:    resourceInformer.Lister(),

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -431,7 +431,12 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	}
 
 	if podconvert.SidecarsReady(pod.Status) {
+		if err := c.metrics.RecordPodLatency(pod, tr); err != nil {
+			logger.Warnf("Failed to log the metrics : %v", err)
+		}
+
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableSpire {
+
 			logger.Infof("Registering SPIRE entry: %v/%v", pod.Namespace, pod.Name)
 			spiffeclient, err := spire.NewSpiffeServerApiClient(ctx, c.SpireConfig)
 			if err != nil {
@@ -453,9 +458,6 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 			return err
 		}
 
-		if err := c.metrics.RecordPodLatency(pod, tr); err != nil {
-			logger.Warnf("Failed to log the metrics : %v", err)
-		}
 	}
 
 	// Convert the Pod's status to the equivalent TaskRun Status.

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -435,8 +435,9 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 		}
 
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableSpire {
-
-			if err = c.SpireClient.CreateEntries(ctx, tr, pod); err != nil {
+			// TTL is in seconds
+			ttl := config.FromContextOrDefaults(ctx).Defaults.DefaultTimeoutMinutes * 60
+			if err = c.SpireClient.CreateEntries(ctx, tr, pod, ttl); err != nil {
 				logger.Errorf("Failed to create workload SPIFFE entry for taskrun %v: %v", tr.Name, err)
 				return err
 			}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -436,12 +436,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableSpire {
 
-			logger.Infof("Registering SPIRE entry: %v/%v", pod.Namespace, pod.Name)
-			if err = c.SpireClient.CreateNodeEntry(ctx, pod.Spec.NodeName); err != nil {
-				logger.Errorf("Failed to create node SPIFFE entry for node %v: %v", pod.Spec.NodeName, err)
-				return err
-			}
-			if err = c.SpireClient.CreateWorkloadEntry(ctx, tr, pod); err != nil {
+			if err = c.SpireClient.CreateEntries(ctx, tr, pod); err != nil {
 				logger.Errorf("Failed to create workload SPIFFE entry for taskrun %v: %v", tr.Name, err)
 				return err
 			}

--- a/pkg/spire/spire.go
+++ b/pkg/spire/spire.go
@@ -106,7 +106,7 @@ func (sc *SpireServerApiClient) NodeEntry(nodeName string) *spiffetypes.Entry {
 	}
 }
 
-func (sc *SpireServerApiClient) WorkloadEntry(tr *v1beta1.TaskRun, pod *corev1.Pod) *spiffetypes.Entry {
+func (sc *SpireServerApiClient) WorkloadEntry(tr *v1beta1.TaskRun, pod *corev1.Pod, ttl int32) *spiffetypes.Entry {
 	// Note: We can potentially add attestation on the container images as well since
 	// the information is available here.
 	selectors := []*spiffetypes.Selector{
@@ -130,17 +130,18 @@ func (sc *SpireServerApiClient) WorkloadEntry(tr *v1beta1.TaskRun, pod *corev1.P
 			Path:        fmt.Sprintf("%v%v", sc.config.NodeAliasPrefix, pod.Spec.NodeName),
 		},
 		Selectors: selectors,
+		Ttl:       ttl,
 	}
 }
 
-func (sc *SpireServerApiClient) CreateEntries(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod) error {
+func (sc *SpireServerApiClient) CreateEntries(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod, ttl int) error {
 	err := sc.checkClient(ctx)
 	if err != nil {
 		return err
 	}
 	entries := []*spiffetypes.Entry{
 		sc.NodeEntry(pod.Spec.NodeName),
-		sc.WorkloadEntry(tr, pod),
+		sc.WorkloadEntry(tr, pod, int32(ttl)),
 	}
 
 	req := entryv1.BatchCreateEntryRequest{

--- a/pkg/spire/spire.go
+++ b/pkg/spire/spire.go
@@ -34,37 +34,59 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-type SpiffeServerApiClient struct {
+type SpireServerApiClient struct {
+	config       spireconfig.SpireConfig
 	serverConn   *grpc.ClientConn
 	workloadConn *workloadapi.X509Source
 	entryClient  entryv1.EntryClient
-	config       spireconfig.SpireConfig
 }
 
-func NewSpiffeServerApiClient(ctx context.Context, c spireconfig.SpireConfig) (*SpiffeServerApiClient, error) {
-	// Create X509Source
-	source, err := workloadapi.NewX509Source(ctx, workloadapi.WithClientOptions(workloadapi.WithAddr("unix://"+c.SocketPath)))
-	if err != nil {
-		return nil, fmt.Errorf("Unable to create X509Source for SPIFFE client: %w", err)
+func (sc *SpireServerApiClient) checkClient(ctx context.Context) error {
+	if sc.entryClient == nil || sc.workloadConn == nil || sc.serverConn == nil {
+		return sc.dial(ctx)
 	}
-
-	// Create connection
-	tlsConfig := tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeAny())
-	conn, err := grpc.DialContext(ctx, c.ServerAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
-	if err != nil {
-		source.Close()
-		return nil, fmt.Errorf("Unable to dial SPIRE server: %w", err)
-	}
-
-	return &SpiffeServerApiClient{
-		serverConn:   conn,
-		workloadConn: source,
-		entryClient:  entryv1.NewEntryClient(conn),
-		config:       c,
-	}, nil
+	return nil
 }
 
-func (sc *SpiffeServerApiClient) CreateNodeEntry(ctx context.Context, nodeName string) error {
+func (sc *SpireServerApiClient) dial(ctx context.Context) error {
+	if sc.workloadConn == nil {
+		// Create X509Source
+		source, err := workloadapi.NewX509Source(ctx, workloadapi.WithClientOptions(workloadapi.WithAddr("unix://"+sc.config.SocketPath)))
+		if err != nil {
+			return fmt.Errorf("Unable to create X509Source for SPIFFE client: %w", err)
+		}
+		sc.workloadConn = source
+	}
+
+	if sc.serverConn == nil {
+		// Create connection
+		tlsConfig := tlsconfig.MTLSClientConfig(sc.workloadConn, sc.workloadConn, tlsconfig.AuthorizeAny())
+		conn, err := grpc.DialContext(ctx, sc.config.ServerAddr, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+		if err != nil {
+			sc.workloadConn.Close()
+			sc.workloadConn = nil
+			return fmt.Errorf("Unable to dial SPIRE server: %w", err)
+		}
+		sc.serverConn = conn
+	}
+
+	sc.entryClient = entryv1.NewEntryClient(sc.serverConn)
+
+	return nil
+}
+
+func NewSpireServerApiClient(c spireconfig.SpireConfig) *SpireServerApiClient {
+	return &SpireServerApiClient{
+		config: c,
+	}
+}
+
+func (sc *SpireServerApiClient) CreateNodeEntry(ctx context.Context, nodeName string) error {
+	err := sc.checkClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	selectors := []*spiffetypes.Selector{
 		{
 			Type:  "k8s_psat",
@@ -112,7 +134,12 @@ func (sc *SpiffeServerApiClient) CreateNodeEntry(ctx context.Context, nodeName s
 	return fmt.Errorf("Batch create entry failed, code: %v", res.Status.Code)
 }
 
-func (sc *SpiffeServerApiClient) CreateWorkloadEntry(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod) error {
+func (sc *SpireServerApiClient) CreateWorkloadEntry(ctx context.Context, tr *v1beta1.TaskRun, pod *corev1.Pod) error {
+	err := sc.checkClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Note: We can potentially add attestation on the container images as well since
 	// the information is available here.
 	selectors := []*spiffetypes.Selector{
@@ -162,7 +189,7 @@ func (sc *SpiffeServerApiClient) CreateWorkloadEntry(ctx context.Context, tr *v1
 	return fmt.Errorf("Batch create entry failed, code: %v", res.Status.Code)
 }
 
-func (sc *SpiffeServerApiClient) Close() {
+func (sc *SpireServerApiClient) Close() {
 	err := sc.serverConn.Close()
 	if err != nil {
 		// Log error


### PR DESCRIPTION
- Add TTL for workload entry based on taskrun timeout
- Optimize spire entry creation
- SPIRE client connection caching
- Record pod latency before SPIRE entry creation

Signed-off-by: Brandon Lum <lumjjb@gmail.com>