### PR TITLE
Fix TTL and Spire Entry delete

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -447,7 +447,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 		}
 
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableSpire {
-			// TTL is in seconds
+			// TTL for the entry is in seconds
 			ttl := config.FromContextOrDefaults(ctx).Defaults.DefaultTimeoutMinutes * 60
 			if err = c.SpireClient.CreateEntries(ctx, tr, pod, ttl); err != nil {
 				logger.Errorf("Failed to create workload SPIFFE entry for taskrun %v: %v", tr.Name, err)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -468,6 +468,14 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 		return err
 	}
 
+	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableSpire && tr.IsDone() {
+		if err := c.SpireClient.DeleteEntry(ctx, tr, pod); err != nil {
+			logger.Infof("Failed to remove workload SPIFFE entry for taskrun %v: %v", tr.Name, err)
+			return err
+		}
+		logger.Infof("Deleted SPIFFE workload entry for %v/%v", tr.Namespace, tr.Name)
+	}
+
 	logger.Infof("Successfully reconciled taskrun %s/%s with status: %#v", tr.Name, tr.Namespace, tr.Status.GetCondition(apis.ConditionSucceeded))
 	return nil
 }


### PR DESCRIPTION
- [Fix ttl to use right entryExpiry field](https://github.com/pxp928/pipeline/commit/920d8bea661c389686094139ad17b01a6906b8f9)[](https://github.com/lumjjb) 
- [Add spire entry delete when taskrun is done](https://github.com/pxp928/pipeline/commit/bf488d2602cba82864dad980168f6daf173dc82f)[](https://github.com/lumjjb)